### PR TITLE
Allow use of relative paths in referenced schema

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -433,7 +433,8 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                 });
             };
 
-            var resolveRefsReentrant = function(schema){
+            var resolveRefsReentrant = function(schema, basePath){
+                if(basePath === undefined) basePath='';
                 traverse(schema).forEach(function(item) {
                     // Fix Swagger weird generation for array.
                     if(item && item.$ref == "array") {
@@ -481,7 +482,7 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                             //Local to this server, fetch relative
                             var segments = item.split("#");
                             refs[item] = null;
-                            var p = $.get(baseUrl + segments[0]).then(function(content) {
+                            var p = $.get(baseUrl + basePath + segments[0]).then(function(content) {
                                 if(typeof content != "object") {
                                     try {
                                         content = JSON.parse(content);
@@ -492,7 +493,8 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                                 if(content) {
                                     refs[item] = content;
                                     renderBox();
-                                    resolveRefsReentrant(content);
+                                    var match = segments[0].match(/.+\//);
+                                    resolveRefsReentrant(content, basePath + (match ? match[0] : ''));
                                 }
                             });
                         }


### PR DESCRIPTION
Currently, if you have a schema with "$ref": "includes/entity.json" and that referenced entity.json schema has "$ref": "person.json", docson will look for the person.json schema at the path person.json instead of at includes/person.json.